### PR TITLE
fix: prevent infinite retry loop for 'less than 5 other links' admin messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/follow/issues/15
-Your prepared branch: issue-15-f61108c0fba6
-Your prepared working directory: /tmp/gh-issue-solver-1763288232851
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/follow/issues/15
+Your prepared branch: issue-15-f61108c0fba6
+Your prepared working directory: /tmp/gh-issue-solver-1763288232851
+
+Proceed.

--- a/experiments/test-admin-skip-message-detection.mjs
+++ b/experiments/test-admin-skip-message-detection.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify admin skip message detection
+ * This tests the regex pattern that detects "ещё НЕ прошло 5 чужих ссылок" messages
+ */
+
+// Test messages
+const testMessages = [
+  {
+    text: '⚠ Константин Дьяченко, ещё НЕ прошло 5 чужих ссылок. Дождитесь.',
+    shouldMatch: true,
+    description: 'Exact message from issue'
+  },
+  {
+    text: '[TG подписки](https://vk.com/club223453532)\n⚠ [Константин Дьяченко](https://vk.com/konard), ещё НЕ прошло 5 чужих ссылок. Дождитесь.',
+    shouldMatch: true,
+    description: 'Message with links and formatting'
+  },
+  {
+    text: 'ещё не прошло 5 чужих ссылок',
+    shouldMatch: true,
+    description: 'Lowercase variation'
+  },
+  {
+    text: 'ЕЩЁ НЕ ПРОШЛО 5 ЧУЖИХ ССЫЛОК',
+    shouldMatch: true,
+    description: 'Uppercase variation'
+  },
+  {
+    text: 'Ваша ссылка удалена',
+    shouldMatch: false,
+    description: 'Generic deletion message'
+  },
+  {
+    text: 'Спам запрещен',
+    shouldMatch: false,
+    description: 'Different admin message'
+  },
+  {
+    text: '',
+    shouldMatch: false,
+    description: 'Empty message'
+  },
+  {
+    text: null,
+    shouldMatch: false,
+    description: 'Null message'
+  }
+];
+
+// The pattern from the implementation
+const skipPattern = /ещё\s+НЕ\s+прошло\s+5\s+чужих\s+ссылок/i;
+
+console.log('🧪 Testing Admin Skip Message Detection\n');
+console.log('='.repeat(60));
+
+let passed = 0;
+let failed = 0;
+
+for (const test of testMessages) {
+  const matches = !!(test.text && skipPattern.test(test.text));
+  const result = matches === test.shouldMatch ? '✅ PASS' : '❌ FAIL';
+
+  if (matches === test.shouldMatch) {
+    passed++;
+  } else {
+    failed++;
+  }
+
+  console.log(`\n${result}: ${test.description}`);
+  console.log(`  Text: ${test.text === null ? 'null' : test.text === '' ? '(empty string)' : `"${test.text}"`}`);
+  console.log(`  Expected: ${test.shouldMatch ? 'MATCH' : 'NO MATCH'}`);
+  console.log(`  Got: ${matches ? 'MATCH' : 'NO MATCH'}`);
+}
+
+console.log('\n' + '='.repeat(60));
+console.log(`📊 Test Results: ${passed} passed, ${failed} failed`);
+console.log('='.repeat(60));
+
+if (failed > 0) {
+  process.exit(1);
+} else {
+  console.log('\n✅ All tests passed!');
+  process.exit(0);
+}


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #15

## 📝 Problem

The auto-follow script was entering an infinite retry loop when VK admin bots deleted messages with the reason "ещё НЕ прошло 5 чужих ссылок" (meaning "less than 5 other links were sent"). This is a temporary condition that requires waiting for other users to post links, not immediate retrying.

### Example admin message:
```
⚠ Константин Дьяченко, ещё НЕ прошло 5 чужих ссылок. Дождитесь.
```

## 🔧 Solution

Implemented smart deletion reason detection that identifies when a message was deleted due to the "less than 5 other links" rule and prevents retry in those cases.

### Changes Made:

1. **Added `checkForAdminSkipMessage()` method** (vk-send-telegram-link-to-chats.mjs:24-58)
   - Fetches recent chat history when a deletion is detected
   - Uses regex pattern `/ещё\s+НЕ\s+прошло\s+5\s+чужих\s+ссылок/i` to detect admin messages
   - Returns true if the skip pattern is found

2. **Enhanced deletion detection** (vk-send-telegram-link-to-chats.mjs:122-143)
   - Calls `checkForAdminSkipMessage()` when a deletion is detected
   - Marks the message info with `skipRetry: true` flag
   - Logs deletion with skip retry indication

3. **Updated retry logic** (vk-send-telegram-link-to-chats.mjs:257-269)
   - Filters out chats marked with `skipRetry` when saving to cache
   - Prevents these chats from being included in retry iterations
   - Clears cache when all deletions are skip retry

4. **Fixed exit codes** (vk-send-telegram-link-to-chats.mjs:272-284)
   - Exit with success (0) when all deleted messages have `skipRetry` flag
   - Exit with failure (1) only when there are deletions that need retry
   - Prevents the auto-follow loop from continuing unnecessarily

## 🧪 Testing

Created comprehensive test script: `experiments/test-admin-skip-message-detection.mjs`

- Tests regex pattern against various message formats
- Validates case-insensitive matching
- Handles edge cases (empty/null messages)
- All 8 test cases passing ✅

### Test Results:
```
✅ PASS: Exact message from issue
✅ PASS: Message with links and formatting  
✅ PASS: Lowercase variation
✅ PASS: Uppercase variation
✅ PASS: Generic deletion message (no match)
✅ PASS: Different admin message (no match)
✅ PASS: Empty message (no match)
✅ PASS: Null message (no match)
```

## 🎯 Expected Behavior

**Before:**
- Message deleted → Added to rejected chats → Infinite retry loop
- Script would retry the same chat repeatedly without success

**After:**  
- Message deleted with "less than 5 other links" reason → Marked as skip retry → No retry
- Message deleted for other reasons → Added to rejected chats → Normal retry
- Script exits successfully when only skip retry deletions occur

## 📊 Impact

- ✅ Prevents infinite retry loops
- ✅ Reduces unnecessary API calls to VK
- ✅ Improves user experience by not spamming the same chat
- ✅ Maintains normal retry behavior for legitimate failures

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)